### PR TITLE
fix bug for reviews_delete function

### DIFF
--- a/main_app/views.py
+++ b/main_app/views.py
@@ -326,7 +326,10 @@ def reviews_delete(request, item_id, review_id):
   seller_review = SellerReview.objects.get(id=review_id)
   seller_review.delete()
   item = Item.objects.get(id=item_id)
-  seller_rating = round(sum([review.rating for review in item.seller.sellerreview_set.all()]) / item.seller.sellerreview_set.all().count(), 2)
+  if item.seller.sellerreview_set.all().count():
+    seller_rating = round(sum([review.rating for review in item.seller.sellerreview_set.all()]) / item.seller.sellerreview_set.all().count(), 2)
+  else:
+    seller_rating = None
   Item.objects.filter(seller=item.seller).update(seller_rating=seller_rating)
   return redirect('buying_history')
 


### PR DESCRIPTION
fix the problem when a seller only has one review that is about to be deleted.
If a seller only has one review, when the review is deleted, seller rating should be updated to be none